### PR TITLE
Reduce tab size to 2 characters

### DIFF
--- a/src/_includes/scss/site.scss
+++ b/src/_includes/scss/site.scss
@@ -444,6 +444,7 @@ a {
 pre {
   margin-top: 32px;
   margin-bottom: 32px;
+  tab-size: 2;
 }
 
 /* body-copy */


### PR DESCRIPTION
I noticed there is a mixture of tabs and spaces used in the code examples for indentation. Examples that use spaces always use two spaces, so I thought I'd change the tab-size to that for consistency.