### PR TITLE
Add tab activation via the 'Space' key

### DIFF
--- a/docs/static/js/gef.js
+++ b/docs/static/js/gef.js
@@ -851,6 +851,18 @@
       panel.hidden = true;
     });
 
+    // Use event delegation to listen to all 'keyup' events
+    // within `tablist`. If 'Space' was pressed on a tab
+    // element, then click it triggering a 'hashchange'.
+    tablist.addEventListener('keyup', function (e) {
+      var isTab = e.target.matches('[role="tab"]');
+      var keyCode = e.code;
+
+      if (isTab && keyCode === 'Space') {
+        e.target.click();
+      }
+    });
+
     window.addEventListener('hashchange', function (e) {
       var selected = tablist.querySelector('[aria-selected="true"]');
       var oldIndex = selected ? Array.prototype.indexOf.call(tabs, selected) : undefined;

--- a/src/_includes/js/components/gef-tabs.js
+++ b/src/_includes/js/components/gef-tabs.js
@@ -66,6 +66,18 @@
       panel.hidden = true;
     });
 
+    // Use event delegation to listen to all 'keyup' events
+    // within `tablist`. If 'Space' was pressed on a tab
+    // element, then click it triggering a 'hashchange'.
+    tablist.addEventListener('keyup', function (e) {
+      var isTab = e.target.matches('[role="tab"]');
+      var keyCode = e.code;
+
+      if (isTab && keyCode === 'Space') {
+        e.target.click();
+      }
+    });
+
     window.addEventListener('hashchange', function (e) {
       var selected = tablist.querySelector('[aria-selected="true"]');
       var oldIndex = selected ? Array.prototype.indexOf.call(tabs, selected) : undefined;

--- a/src/components/tabs.md
+++ b/src/components/tabs.md
@@ -173,7 +173,7 @@ The links and `<section>`s are communicated as such in screen reader output and 
 
 #### Selecting a tab
 
-By mouse or touch, clicking or pressing a tab will reveal its corresponding tab panel. For keyboard users, unselected tabs are focusable and can be activated with the <kbd>Enter</kbd> key. 
+By mouse or touch, clicking or pressing a tab will reveal its corresponding tab panel. For keyboard users, unselected tabs are focusable and can be activated with the <kbd>Enter</kbd> and <kbd>Space</kbd> keys. 
 
 To preserve the behaviour of the same-page links upon which the tabs are created and to address trouble screen readers have been observed experiencing moving from the tab to the tab panel, clicking a tab programmatically moves focus to the visible tab panel. The tab panel is identified in screen readers as a tab panel, and the tab panel's label (borrowed from the corresponding tab using `aria-labelledby`) is also announced. 
 

--- a/src/static/js/gef.js
+++ b/src/static/js/gef.js
@@ -851,6 +851,18 @@
       panel.hidden = true;
     });
 
+    // Use event delegation to listen to all 'keyup' events
+    // within `tablist`. If 'Space' was pressed on a tab
+    // element, then click it triggering a 'hashchange'.
+    tablist.addEventListener('keyup', function (e) {
+      var isTab = e.target.matches('[role="tab"]');
+      var keyCode = e.code;
+
+      if (isTab && keyCode === 'Space') {
+        e.target.click();
+      }
+    });
+
     window.addEventListener('hashchange', function (e) {
       var selected = tablist.querySelector('[aria-selected="true"]');
       var oldIndex = selected ? Array.prototype.indexOf.call(tabs, selected) : undefined;


### PR DESCRIPTION
Resolves issue #90. Tested in Chrome, FF and Safari.

- When a keyup event that matches the 'Space' key originates from a tab in `tablist`, click the tab.
- This triggers a hashchange and existing logic takes care of the rest - panel switching etc.