### PR TITLE
Add paginated demo to Load more

### DIFF
--- a/docs/components/demos/load-more-paginated/index.html
+++ b/docs/components/demos/load-more-paginated/index.html
@@ -98,12 +98,6 @@
   </div>
 </div>
 
-<script type="text/javascript">
-  function LoadMorePaginated(elem) {
-    this.elem = elem;
-  }
-</script>
-
             </div>
         </div>
     </main>

--- a/docs/components/demos/load-more-paginated/index.html
+++ b/docs/components/demos/load-more-paginated/index.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en" class="b-pw-1280 b-reith-sans-font b-reith-serif-font no-js">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="/gef-docs/static/images/favicon.ico" type="image/x-icon">
+
+    <title>GEF | Load more – paginated Demo</title>
+
+    <link rel="stylesheet" type="text/css" href="/gef-docs/static/css/gef.css">
+
+    <script type="text/javascript"> // feature detects
+        document.documentElement.className = document.documentElement.className.replace(' no-js', ' js');
+        document.documentElement.className += (' ' + ('ontouchstart' in document.documentElement ? 'touch' : 'no-touch'));
+        document.documentElement.className += (' ' + ('flexWrap' in document.documentElement.style ? 'flex' : 'no-flex'));
+        document.documentElement.className += (' ' + ((document.createElementNS && 'createSVGRect' in document.createElementNS('http://www.w3.org/2000/svg', 'svg')) ? 'svg' : 'no-svg'));
+    </script>
+
+    
+</head>
+
+<body class="gel-guideline-body">
+    <main id="main" class="gel-wrap gs-u-clearfix">
+        <div class="gel-layout">
+            <div class="gel-layout__item gel-5/5@l" style="padding-right: 12px;">
+                <h1 class="gel-guideline-header__title">Load more – paginated</h1>
+            </div>
+        </div>
+
+        <div class="gel-layout">
+            <div class="gel-guideline-sections gel-body-copy gel-layout__item gel-5/5@l">
+                <h2>Reference implementation</h2>
+
+                
+<div class="gef-loader">
+  <ul class="gef-loader__items">
+    <li class="gef-loader__item">
+      <p>delectus ullam et corporis nulla voluptas sequi</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/1">Read more about result 1</a>
+    </li>
+    <li class="gef-loader__item">
+      <p>iusto eius quod necessitatibus culpa ea</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/2">Read more about result 2</a>
+    </li>
+    <li class="gef-loader__item">
+      <p>a quo magni similique perferendis</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/3">Read more about result 3</a>
+    </li>
+    <li class="gef-loader__item">
+      <p>ullam ut quidem id aut vel consequuntur</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/4">Read more about result 4</a>
+    </li>
+    <li class="gef-loader__item">
+      <p>doloremque illum aliquid sunt</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/5">Read more about result 5</a>
+    </li>
+    <li class="gef-loader__item">
+      <p>qui explicabo molestiae dolorem</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/6">Read more about result 6</a>
+    </li>
+  </ul>
+  <div class="gef-loader__foot">
+    <div class="gef-loader__loading" role="status" hidden>
+      <svg class="gel-icon gel-icon--text gel-icon-loading" focusable="false" aria-hidden="true">
+        <use xlink:href="/gef-docs/static/images/gel-icons-all.svg#gel-icon-loading"></use>
+      </svg>
+      <div class="gef-loader__loading-text gef-sr"></div>
+    </div>
+    <button class="gef-loader__button gef-button" type="button" hidden>Load more</button>
+    <nav class="gef-pages" aria-labelledby="gef-pagination-label">
+      <div id="gef-pages__label" hidden>Page</div>
+      <a class="gef-pages__prev">
+        <span class="gef-sr">Previous page</span>
+        <svg class="gel-icon gel-icon--text" focusable="false" aria-hidden="true">
+          <use xlink:href="/gef-docs/static/images/gel-icons-all.svg#gel-icon-previous"></use>
+        </svg>
+      </a>
+      <ol class="gef-pages__numbered">
+        <li><a href="?page=1" aria-current="page">1</a></li>
+        <li><a href="?page=2">2</a></li>
+        <li><a href="?page=3">3</a></li>
+        <li><a href="?page=4">4</a></li>
+        <li><a href="?page=5">5</a></li>
+        <li><a href="?page=6">6</a></li>
+        <li><a href="?page=7">7</a></li>
+        <li role="separator">&hellip;</li>
+        <li><a href="?page=999">999</a></li>
+      </ol>
+      <div class="gef-pages__text">Page 1 of 999</div>
+      <a class="gef-pages__next" href="?page=2">
+        <span class="gef-sr">Next page</span>
+        <svg class="gel-icon gel-icon--text" focusable="false" aria-hidden="true">
+          <use xlink:href="/gef-docs/static/images/gel-icons-all.svg#gel-icon-next"></use>
+        </svg>
+      </a>
+    </nav>
+  </div>
+</div>
+
+<script type="text/javascript">
+  function LoadMorePaginated(elem) {
+    this.elem = elem;
+  }
+</script>
+
+            </div>
+        </div>
+    </main>
+
+    <script nomodule defer type="text/javascript" src="/gef-docs/static/js/external-svg-polyfill.js"></script>
+    <script type="text/javascript" src="/gef-docs/static/js/gef.js"></script>
+
+    
+</body>
+
+</html>

--- a/docs/components/load-more/index.html
+++ b/docs/components/load-more/index.html
@@ -255,9 +255,9 @@
 <p>For maximum backwards compatibility with minimum code, <code>inline-block</code> places the items side-by-side. In the <a href="#reference-implementation">Reference implementation</a>, the expanded layout (with 9 numbered items, including the ellipsis and end item) switches down to the compact version (with the text element; specified in <a href="https://www.bbc.co.uk/gel/guidelines/numbered-pagination">GEL Numbered Pagination</a>) at <code>650px</code>. This will differ for your setup due to the inevitable discrepancy between the pagination container's and the viewport's width. It will need adjusting.</p>
 <pre class="hljs"><code>@<span class="hljs-keyword">media</span> (min-width: <span class="hljs-number">650px</span>) {
   <span class="hljs-selector-class">.gef-pages-text</span> {
-    <span class="hljs-attribute">display</span>: none;  
+    <span class="hljs-attribute">display</span>: none;
   }
-  
+
   <span class="hljs-selector-class">.gef-pages-numbered</span> {
     <span class="hljs-attribute">display</span>: inline-block;
   }
@@ -292,7 +292,7 @@
 
 <span class="hljs-keyword">var</span> loaderElem = <span class="hljs-built_in">document</span>.querySelector(<span class="hljs-string">'.gef-loader'</span>);
 <span class="hljs-keyword">var</span> loader = <span class="hljs-keyword">new</span> gef.LoadMore.constructor(
-  loaderElem, 
+  loaderElem,
   <span class="hljs-number">6</span>, <span class="hljs-comment">// The number of results fetched each time</span>
   <span class="hljs-number">7</span>, <span class="hljs-comment">// The starting result (6 items server rendered + 1)</span>
   baseURL
@@ -506,6 +506,85 @@ title: Load more
 </script></div>
         
           <p><a class="gef-cta gel-long-primer-bold" href="../demos/load-more/" target="_new"><span class="gef-button__label">Open in new window</span><svg class="gef-button__icon gef-icon gel-icon--text"><use xlink:href="/gef-docs/static/images/gel-icons-core-set.svg#gel-icon-external-link"></use></svg></a></p>
+        <h3 id="paginated">Paginated</h3>
+
+          <div class="gefdocs-demo"><!-- 
+title: Load more – paginated
+ -->
+
+<div class="gef-loader">
+  <ul class="gef-loader__items">
+    <li class="gef-loader__item">
+      <p>delectus ullam et corporis nulla voluptas sequi</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/1">Read more about result 1</a>
+    </li>
+    <li class="gef-loader__item">
+      <p>iusto eius quod necessitatibus culpa ea</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/2">Read more about result 2</a>
+    </li>
+    <li class="gef-loader__item">
+      <p>a quo magni similique perferendis</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/3">Read more about result 3</a>
+    </li>
+    <li class="gef-loader__item">
+      <p>ullam ut quidem id aut vel consequuntur</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/4">Read more about result 4</a>
+    </li>
+    <li class="gef-loader__item">
+      <p>doloremque illum aliquid sunt</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/5">Read more about result 5</a>
+    </li>
+    <li class="gef-loader__item">
+      <p>qui explicabo molestiae dolorem</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/6">Read more about result 6</a>
+    </li>
+  </ul>
+  <div class="gef-loader__foot">
+    <div class="gef-loader__loading" role="status" hidden>
+      <svg class="gel-icon gel-icon--text gel-icon-loading" focusable="false" aria-hidden="true">
+        <use xlink:href="/gef-docs/static/images/gel-icons-all.svg#gel-icon-loading"></use>
+      </svg>
+      <div class="gef-loader__loading-text gef-sr"></div>
+    </div>
+    <button class="gef-loader__button gef-button" type="button" hidden>Load more</button>
+    <nav class="gef-pages" aria-labelledby="gef-pagination-label">
+      <div id="gef-pages__label" hidden>Page</div>
+      <a class="gef-pages__prev">
+        <span class="gef-sr">Previous page</span>
+        <svg class="gel-icon gel-icon--text" focusable="false" aria-hidden="true">
+          <use xlink:href="/gef-docs/static/images/gel-icons-all.svg#gel-icon-previous"></use>
+        </svg>
+      </a>
+      <ol class="gef-pages__numbered">
+        <li><a href="?page=1" aria-current="page">1</a></li>
+        <li><a href="?page=2">2</a></li>
+        <li><a href="?page=3">3</a></li>
+        <li><a href="?page=4">4</a></li>
+        <li><a href="?page=5">5</a></li>
+        <li><a href="?page=6">6</a></li>
+        <li><a href="?page=7">7</a></li>
+        <li role="separator">&hellip;</li>
+        <li><a href="?page=999">999</a></li>
+      </ol>
+      <div class="gef-pages__text">Page 1 of 999</div>
+      <a class="gef-pages__next" href="?page=2">
+        <span class="gef-sr">Next page</span>
+        <svg class="gel-icon gel-icon--text" focusable="false" aria-hidden="true">
+          <use xlink:href="/gef-docs/static/images/gel-icons-all.svg#gel-icon-next"></use>
+        </svg>
+      </a>
+    </nav>
+  </div>
+</div>
+
+<script type="text/javascript">
+  function LoadMorePaginated(elem) {
+    this.elem = elem;
+  }
+</script>
+</div>
+        
+          <p><a class="gef-cta gel-long-primer-bold" href="../demos/load-more-paginated/" target="_new"><span class="gef-button__label">Open in new window</span><svg class="gef-button__icon gef-icon gel-icon--text"><use xlink:href="/gef-docs/static/images/gel-icons-core-set.svg#gel-icon-external-link"></use></svg></a></p>
         <h2 id="related-research">Related research</h2>
 <p>This topic does not yet have any related research available.</p>
 <h3 id="further-reading-elsewhere-on-the-web">Further reading, elsewhere on the Web</h3>

--- a/docs/components/load-more/index.html
+++ b/docs/components/load-more/index.html
@@ -576,12 +576,6 @@ title: Load more – paginated
     </nav>
   </div>
 </div>
-
-<script type="text/javascript">
-  function LoadMorePaginated(elem) {
-    this.elem = elem;
-  }
-</script>
 </div>
         
           <p><a class="gef-cta gel-long-primer-bold" href="../demos/load-more-paginated/" target="_new"><span class="gef-button__label">Open in new window</span><svg class="gef-button__icon gef-icon gel-icon--text"><use xlink:href="/gef-docs/static/images/gel-icons-core-set.svg#gel-icon-external-link"></use></svg></a></p>

--- a/src/components/demos/load-more-paginated.html
+++ b/src/components/demos/load-more-paginated.html
@@ -1,0 +1,74 @@
+---
+title: Load more – paginated
+---
+
+<div class="gef-loader">
+  <ul class="gef-loader__items">
+    <li class="gef-loader__item">
+      <p>delectus ullam et corporis nulla voluptas sequi</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/1">Read more about result 1</a>
+    </li>
+    <li class="gef-loader__item">
+      <p>iusto eius quod necessitatibus culpa ea</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/2">Read more about result 2</a>
+    </li>
+    <li class="gef-loader__item">
+      <p>a quo magni similique perferendis</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/3">Read more about result 3</a>
+    </li>
+    <li class="gef-loader__item">
+      <p>ullam ut quidem id aut vel consequuntur</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/4">Read more about result 4</a>
+    </li>
+    <li class="gef-loader__item">
+      <p>doloremque illum aliquid sunt</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/5">Read more about result 5</a>
+    </li>
+    <li class="gef-loader__item">
+      <p>qui explicabo molestiae dolorem</p>
+      <a class="gef-cta" href="http://www.example.com/path/to/6">Read more about result 6</a>
+    </li>
+  </ul>
+  <div class="gef-loader__foot">
+    <div class="gef-loader__loading" role="status" hidden>
+      <svg class="gel-icon gel-icon--text gel-icon-loading" focusable="false" aria-hidden="true">
+        <use xlink:href="{{site.basedir}}static/images/gel-icons-all.svg#gel-icon-loading"></use>
+      </svg>
+      <div class="gef-loader__loading-text gef-sr"></div>
+    </div>
+    <button class="gef-loader__button gef-button" type="button" hidden>Load more</button>
+    <nav class="gef-pages" aria-labelledby="gef-pagination-label">
+      <div id="gef-pages__label" hidden>Page</div>
+      <a class="gef-pages__prev">
+        <span class="gef-sr">Previous page</span>
+        <svg class="gel-icon gel-icon--text" focusable="false" aria-hidden="true">
+          <use xlink:href="{{site.basedir}}static/images/gel-icons-all.svg#gel-icon-previous"></use>
+        </svg>
+      </a>
+      <ol class="gef-pages__numbered">
+        <li><a href="?page=1" aria-current="page">1</a></li>
+        <li><a href="?page=2">2</a></li>
+        <li><a href="?page=3">3</a></li>
+        <li><a href="?page=4">4</a></li>
+        <li><a href="?page=5">5</a></li>
+        <li><a href="?page=6">6</a></li>
+        <li><a href="?page=7">7</a></li>
+        <li role="separator">&hellip;</li>
+        <li><a href="?page=999">999</a></li>
+      </ol>
+      <div class="gef-pages__text">Page 1 of 999</div>
+      <a class="gef-pages__next" href="?page=2">
+        <span class="gef-sr">Next page</span>
+        <svg class="gel-icon gel-icon--text" focusable="false" aria-hidden="true">
+          <use xlink:href="{{site.basedir}}static/images/gel-icons-all.svg#gel-icon-next"></use>
+        </svg>
+      </a>
+    </nav>
+  </div>
+</div>
+
+<script type="text/javascript">
+  function LoadMorePaginated(elem) {
+    this.elem = elem;
+  }
+</script>

--- a/src/components/demos/load-more-paginated.html
+++ b/src/components/demos/load-more-paginated.html
@@ -66,9 +66,3 @@ title: Load more – paginated
     </nav>
   </div>
 </div>
-
-<script type="text/javascript">
-  function LoadMorePaginated(elem) {
-    this.elem = elem;
-  }
-</script>

--- a/src/components/load-more.md
+++ b/src/components/load-more.md
@@ -242,6 +242,12 @@ Reference implementations are intended to demonstrate **what needs to be achieve
 
 <cta label="Open in new window" href="../demos/load-more/">
 
+### Paginated
+
+<include src="components/demos/load-more-paginated.html">
+
+<cta label="Open in new window" href="../demos/load-more-paginated/">
+
 ## Related research
 
 This topic does not yet have any related research available.

--- a/src/components/load-more.md
+++ b/src/components/load-more.md
@@ -186,9 +186,9 @@ For maximum backwards compatibility with minimum code, `inline-block` places the
 ```css
 @media (min-width: 650px) {
   .gef-pages-text {
-    display: none;  
+    display: none;
   }
-  
+
   .gef-pages-numbered {
     display: inline-block;
   }
@@ -214,7 +214,7 @@ The behaviour differs depending on whether JavaScript has run and the `Promise` 
 3. When the button is pressed, the loading indicator ('spinner') appears above the button, and _"loading, please wait"_ is announced in screen readers via the supplemental live region.
 4. When the results have been fetched, two things happen:
     1. The loading indicator is hidden, and the live region emptied of content. In some setups this will silence the region immediately; in others the _"loading, please wait"_ message will be read out in its entirety (if it has not been already).
-    2. The results appear, introduced by a separator element. This element confirms how many items have been loaded (_"items 12 to 18:"_, for example) and is focused. 
+    2. The results appear, introduced by a separator element. This element confirms how many items have been loaded (_"items 12 to 18:"_, for example) and is focused.
 5. The focused separator element announces its confirmation text in screen reader software and places the keyboard user in an appropriate position to browse to the newly appended items.
 
 Note that the specific behaviour and messaging in the [Reference implementation](#reference-implementation) (and the JavaScript used to achieve it) is partly dependent on the nature of the dummy data being used. In this case, items can be fetched using a base URL and enumeration.
@@ -225,7 +225,7 @@ var baseURL = 'https://jsonplaceholder.typicode.com/posts/';
 
 var loaderElem = document.querySelector('.gef-loader');
 var loader = new gef.LoadMore.constructor(
-  loaderElem, 
+  loaderElem,
   6, // The number of results fetched each time
   7, // The starting result (6 items server rendered + 1)
   baseURL


### PR DESCRIPTION
As requested by Michael, I've added a second demo to show the paginated load more pattern. This simply uses the existing non-enhanced demo as a base.

Later we might want to fake the server-side stuff, so we can show what it'd be like to move through the pages - this requires some UX/GEL consensus.

