### PR TITLE
DPTOPICS-1184/update docs to reflect shift from `dl` to `ul`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ Then navigate to the resulting server address like `http://localhost:3000/compon
 
 ## Licence
 
-The code in this repositoy is used to generate our documentation and is unlicenced. The generated documentation itself is published at <https://bbc.github.io/gel/> and is licenced under the [Open Government Licence](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/), unless otherwise noted.
+The code in this repository is used to generate our documentation and is unlicenced. The generated documentation itself is published at <https://bbc.github.io/gel/> and is licenced under the [Open Government Licence](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/), unless otherwise noted.

--- a/_content/components/metadata-strips.md
+++ b/_content/components/metadata-strips.md
@@ -1,7 +1,7 @@
 ---
 title: Metadata strips
 summary: The metadata strip defines key metadata for an item of content, in a compact form
-version: 0.1.0
+version: 1.0.0
 published: true
 accessibility: true
 linkback: http://www.bbc.co.uk/gel/guidelines/cards

--- a/_content/components/metadata-strips.md
+++ b/_content/components/metadata-strips.md
@@ -55,7 +55,7 @@ The `<ul>` must have its user agent styles removed. The child `<li>`s are set to
 }
 ```
 
-The purpose of `nowrap` is to ensure pairs of titles and descriptions wrap together and are never split across lines. This aids scanning and comprehension.
+The purpose of `nowrap` is to ensure items are never split across lines. This aids scanning and comprehension.
 
 A border separator is included between—and only between—definition `<li>`s using pseudo-content:
 

--- a/_content/components/metadata-strips.md
+++ b/_content/components/metadata-strips.md
@@ -18,10 +18,10 @@ The following example assumes the content is a [Promo](../promos) and includes j
 :::
 
 ```html
-<dl class="gel-metadata-strip">
-  <div>
-    <dt class="gel-sr">Published:</dt>
-    <dd>
+<ul class="gel-metadata-strip">
+  <li>
+    <span class="gel-sr">Published:</span>
+    <div>
       <span aria-hidden="true">
         <svg class="gel-icon gel-icon--text" focusable="false">
           <use xlink:href="path/to/gel-icons-all.svg#gel-icon-duration"></use>
@@ -29,39 +29,38 @@ The following example assumes the content is a [Promo](../promos) and includes j
         1m
       </span>
       <span class="gel-sr">1 minute ago</span>
-    </dd>
-  </div>
-  <div>
-    <dt class="gel-sr">From:</dt>
-    <dd>
+    </div>
+  </li>
+  <li>
+    <span class="gel-sr">From:</span>
+    <div>
       <a href="link/to/category">UK</a>
-    </dd>
-  </div>
-</dl>
+    </div>
+  </li>
+</ul>
 ```
 
-* **`<dl>` and `<div>`:** The most appropriate markup for key/value based information is the definition (or 'description') list. It is permitted[^1] to use `<div>` elements to wrap pairs of `<dt>` and `<dd>` elements for layout purposes. 
-* **`class="gel-sr"` for `<dt>`:** The definition titles (`<dt>`s) are only needed for non-visual clarification in screen reader output. They are hidden visually using the `gel-sr` class.
-* **gel-icon:** The SVG icon (if present) is hidden along with the display text. It takes `focusable="false"` to remove it from focus order in some versions of IE and Edge[^2]
-* **`aria-hidden="true"`** In some cases, the visually displayed text may not be sufficient for synthetic voice announcement. In these cases, the displayed text (and associated iconography) is hidden from assistive technologies with `aria-hidden="true"`[^3] and an alternative wording is provided non-visually (using the `gel-sr` class to hide this text visually).
+* **`class="gel-sr"` for `<span>`:** These are only needed for non-visual clarification in screen reader output. They are hidden visually using the `gel-sr` class.
+* **gel-icon:** The SVG icon (if present) is hidden along with the display text. It takes `focusable="false"` to remove it from focus order in some versions of IE and Edge[^1]
+* **`aria-hidden="true"`** In some cases, the visually displayed text may not be sufficient for synthetic voice announcement. In these cases, the displayed text (and associated iconography) is hidden from assistive technologies with `aria-hidden="true"`[^2] and an alternative wording is provided non-visually (using the `gel-sr` class to hide this text visually).
 
 ## Recommended layout
 
-The `<dl>`, `<dt>`, and `<dd>` must have their user agent styles removed. The child `<div>`s are set to `inline-block`, with `white-space: nowrap`.
+The `<ul>` must have its user agent styles removed. The child `<li>`s are set to `inline-block`, with `white-space: nowrap`.
 
 ```css
-.gel-metadata-strip > div {
+.gel-metadata-strip > li {
   display: inline-block;
   white-space: nowrap;
 }
 ```
 
-The purpose of `nowrap` is to ensure pairs of definition titles and their definitions wrap together and are never split across lines. This aids scanning and comprehension.
+The purpose of `nowrap` is to ensure pairs of titles and descriptions wrap together and are never split across lines. This aids scanning and comprehension.
 
-A border separator is included between—and only between—definition `<div>`s using pseudo-content:
+A border separator is included between—and only between—definition `<li>`s using pseudo-content:
 
 ```css
-.gel-metadata-strip > div + div::before {
+.gel-metadata-strip > li + li::before {
   content: '';
   border-left: 1px solid;
   margin: 0 0.25rem;
@@ -72,7 +71,7 @@ This is preferable to using a character such as a pip ("|") which will be announ
 
 ### Links
 
-Some metadata values may be linked, such as the 'From' value in the [**Expected markup**](#expected-markup) example. It is important these links are not differentiated by colour alone[^4]. People who are colour-blind or who use non-colour displays cannot perceive colour differences and will not be able to distinguish the link.
+Some metadata values may be linked, such as the 'From' value in the [**Expected markup**](#expected-markup) example. It is important these links are not differentiated by colour alone[^3]. People who are colour-blind or who use non-colour displays cannot perceive colour differences and will not be able to distinguish the link.
 
 Accompany any colour differentiation with `text-decoration: underline`, if this style is not already being inherited.
 
@@ -113,7 +112,6 @@ This topic does not yet have any related research available.
 
 ### Further reading, elsewhere on the Web
 
-[^1]: "Allow &lt;div> around each &lt;dt>&lt;dd> group in &lt;dl>" (WHATWG merged pull request), <https://github.com/whatwg/html/pull/1945>
-[^2]: Don't make every `<svg>` focusable by default (issue) — Microsoft, <https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8090208/>
-[^3]: "Accessibility chops: `hidden` and `aria-hidden`" — The Paciello Group, <https://developer.paciellogroup.com/blog/2012/05/html5-accessibility-chops-hidden-and-aria-hidden/>
-[^4]: Use Of Color: Understanding WCAG 1.4.1, <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html>
+[^1]: Don't make every `<svg>` focusable by default (issue) — Microsoft, <https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8090208/>
+[^2]: "Accessibility chops: `hidden` and `aria-hidden`" — The Paciello Group, <https://developer.paciellogroup.com/blog/2012/05/html5-accessibility-chops-hidden-and-aria-hidden/>
+[^3]: Use Of Color: Understanding WCAG 1.4.1, <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html>

--- a/_content/components/metadata-strips.md
+++ b/_content/components/metadata-strips.md
@@ -20,7 +20,7 @@ The following example assumes the content is a [Promo](../promos) and includes j
 ```html
 <ul class="gel-metadata-strip">
   <li>
-    <span class="gel-sr">Published:</span>
+    <div class="gel-sr">Published:</div>
     <div>
       <span aria-hidden="true">
         <svg class="gel-icon gel-icon--text" focusable="false">
@@ -32,7 +32,7 @@ The following example assumes the content is a [Promo](../promos) and includes j
     </div>
   </li>
   <li>
-    <span class="gel-sr">From:</span>
+    <div class="gel-sr">From:</div>
     <div>
       <a href="link/to/category">UK</a>
     </div>
@@ -40,7 +40,7 @@ The following example assumes the content is a [Promo](../promos) and includes j
 </ul>
 ```
 
-* **`class="gel-sr"` for `<span>`:** These are only needed for non-visual clarification in screen reader output. They are hidden visually using the `gel-sr` class.
+* **`class="gel-sr"` for `<div>`:** These are only needed for non-visual clarification in screen reader output. They are hidden visually using the `gel-sr` class.
 * **gel-icon:** The SVG icon (if present) is hidden along with the display text. It takes `focusable="false"` to remove it from focus order in some versions of IE and Edge[^1]
 * **`aria-hidden="true"`** In some cases, the visually displayed text may not be sufficient for synthetic voice announcement. In these cases, the displayed text (and associated iconography) is hidden from assistive technologies with `aria-hidden="true"`[^2] and an alternative wording is provided non-visually (using the `gel-sr` class to hide this text visually).
 

--- a/_content/components/metadata-strips.md
+++ b/_content/components/metadata-strips.md
@@ -114,4 +114,4 @@ This topic does not yet have any related research available.
 
 [^1]: Don't make every `<svg>` focusable by default (issue) — Microsoft, <https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8090208/>
 [^2]: "Accessibility chops: `hidden` and `aria-hidden`" — The Paciello Group, <https://developer.paciellogroup.com/blog/2012/05/html5-accessibility-chops-hidden-and-aria-hidden/>
-[^3]: Use Of Color: Understanding WCAG 1.4.1, <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html>
+[^3]: Understanding Success Criterion 1.4.1: Use of Color, <https://www.w3.org/WAI/WCAG21/Understanding/use-of-color>

--- a/docs/components/metadata-strips/index.html
+++ b/docs/components/metadata-strips/index.html
@@ -146,7 +146,7 @@
   white-space: nowrap;
 }
 </code></pre>
-<p>The purpose of <code>nowrap</code> is to ensure pairs of titles and descriptions wrap together and are never split across lines. This aids scanning and comprehension.</p>
+<p>The purpose of <code>nowrap</code> is to ensure items are never split across lines. This aids scanning and comprehension.</p>
 <p>A border separator is included between—and only between—definition <code>&lt;li&gt;</code>s using pseudo-content:</p>
 <pre><code class="prettyprint syntax-css">.gel-metadata-strip &gt; li + li::before {
   content: '';
@@ -211,7 +211,7 @@ title: Metadata Strips
 </li>
 <li id="fn2" class="footnote-item"><p>&quot;Accessibility chops: <code>hidden</code> and <code>aria-hidden</code>&quot; — The Paciello Group, <a href="https://developer.paciellogroup.com/blog/2012/05/html5-accessibility-chops-hidden-and-aria-hidden/">https://developer.paciellogroup.com/blog/2012/05/html5-accessibility-chops-hidden-and-aria-hidden/</a> <a href="#fnref2" class="footnote-backref">↩︎</a></p>
 </li>
-<li id="fn3" class="footnote-item"><p>Use Of Color: Understanding WCAG 1.4.1, <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html">https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html</a> <a href="#fnref3" class="footnote-backref">↩︎</a></p>
+<li id="fn3" class="footnote-item"><p>Understanding Success Criterion 1.4.1: Use of Color, <a href="https://www.w3.org/WAI/WCAG21/Understanding/use-of-color">https://www.w3.org/WAI/WCAG21/Understanding/use-of-color</a> <a href="#fnref3" class="footnote-backref">↩︎</a></p>
 </li>
 </ol>
 </section>

--- a/docs/components/metadata-strips/index.html
+++ b/docs/components/metadata-strips/index.html
@@ -115,7 +115,7 @@
                     <h4 id="aside-info-promo-implementation" aria-hidden="true"><svg class="geltags-breakout-box__icon geltags-icon geltags-icon--text"><use xlink:href="/gel/static/images/gel-icons-core-set.svg#gel-icon-info" style="fill:#404040;"></use></svg>Promo implementation</h4><div><p>The following example assumes the content is a <a href="../promos">Promo</a> and includes just publishing and derivation information. Other definitions may be applicable elsewhere.</p>
 </aside><pre><code class="prettyprint syntax-html">&lt;ul class=&quot;gel-metadata-strip&quot;&gt;
   &lt;li&gt;
-    &lt;span class=&quot;gel-sr&quot;&gt;Published:&lt;/span&gt;
+    &lt;div class=&quot;gel-sr&quot;&gt;Published:&lt;/div&gt;
     &lt;div&gt;
       &lt;span aria-hidden=&quot;true&quot;&gt;
         &lt;svg class=&quot;gel-icon gel-icon--text&quot; focusable=&quot;false&quot;&gt;
@@ -127,7 +127,7 @@
     &lt;/div&gt;
   &lt;/li&gt;
   &lt;li&gt;
-    &lt;span class=&quot;gel-sr&quot;&gt;From:&lt;/span&gt;
+    &lt;div class=&quot;gel-sr&quot;&gt;From:&lt;/div&gt;
     &lt;div&gt;
       &lt;a href=&quot;link/to/category&quot;&gt;UK&lt;/a&gt;
     &lt;/div&gt;
@@ -135,7 +135,7 @@
 &lt;/ul&gt;
 </code></pre>
 <ul>
-<li><strong><code>class=&quot;gel-sr&quot;</code> for <code>&lt;span&gt;</code>:</strong> These are only needed for non-visual clarification in screen reader output. They are hidden visually using the <code>gel-sr</code> class.</li>
+<li><strong><code>class=&quot;gel-sr&quot;</code> for <code>&lt;div&gt;</code>:</strong> These are only needed for non-visual clarification in screen reader output. They are hidden visually using the <code>gel-sr</code> class.</li>
 <li><strong>gel-icon:</strong> The SVG icon (if present) is hidden along with the display text. It takes <code>focusable=&quot;false&quot;</code> to remove it from focus order in some versions of IE and Edge<sup class="footnote-ref"><a href="#fn1" id="fnref1">[1]</a></sup></li>
 <li><strong><code>aria-hidden=&quot;true&quot;</code></strong> In some cases, the visually displayed text may not be sufficient for synthetic voice announcement. In these cases, the displayed text (and associated iconography) is hidden from assistive technologies with <code>aria-hidden=&quot;true&quot;</code><sup class="footnote-ref"><a href="#fn2" id="fnref2">[2]</a></sup> and an alternative wording is provided non-visually (using the <code>gel-sr</code> class to hide this text visually).</li>
 </ul>

--- a/docs/components/metadata-strips/index.html
+++ b/docs/components/metadata-strips/index.html
@@ -113,10 +113,10 @@
 
                     <aside class="geltags-breakout-box geltags-breakout-box extra-padding" aria-labelledby="aside-info-promo-implementation">
                     <h4 id="aside-info-promo-implementation" aria-hidden="true"><svg class="geltags-breakout-box__icon geltags-icon geltags-icon--text"><use xlink:href="/gel/static/images/gel-icons-core-set.svg#gel-icon-info" style="fill:#404040;"></use></svg>Promo implementation</h4><div><p>The following example assumes the content is a <a href="../promos">Promo</a> and includes just publishing and derivation information. Other definitions may be applicable elsewhere.</p>
-</aside><pre><code class="prettyprint syntax-html">&lt;dl class=&quot;gel-metadata-strip&quot;&gt;
-  &lt;div&gt;
-    &lt;dt class=&quot;gel-sr&quot;&gt;Published:&lt;/dt&gt;
-    &lt;dd&gt;
+</aside><pre><code class="prettyprint syntax-html">&lt;ul class=&quot;gel-metadata-strip&quot;&gt;
+  &lt;li&gt;
+    &lt;span class=&quot;gel-sr&quot;&gt;Published:&lt;/span&gt;
+    &lt;div&gt;
       &lt;span aria-hidden=&quot;true&quot;&gt;
         &lt;svg class=&quot;gel-icon gel-icon--text&quot; focusable=&quot;false&quot;&gt;
           &lt;use xlink:href=&quot;path/to/gel-icons-all.svg#gel-icon-duration&quot;&gt;&lt;/use&gt;
@@ -124,32 +124,31 @@
         1m
       &lt;/span&gt;
       &lt;span class=&quot;gel-sr&quot;&gt;1 minute ago&lt;/span&gt;
-    &lt;/dd&gt;
-  &lt;/div&gt;
-  &lt;div&gt;
-    &lt;dt class=&quot;gel-sr&quot;&gt;From:&lt;/dt&gt;
-    &lt;dd&gt;
+    &lt;/div&gt;
+  &lt;/li&gt;
+  &lt;li&gt;
+    &lt;span class=&quot;gel-sr&quot;&gt;From:&lt;/span&gt;
+    &lt;div&gt;
       &lt;a href=&quot;link/to/category&quot;&gt;UK&lt;/a&gt;
-    &lt;/dd&gt;
-  &lt;/div&gt;
-&lt;/dl&gt;
+    &lt;/div&gt;
+  &lt;/li&gt;
+&lt;/ul&gt;
 </code></pre>
 <ul>
-<li><strong><code>&lt;dl&gt;</code> and <code>&lt;div&gt;</code>:</strong> The most appropriate markup for key/value based information is the definition (or 'description') list. It is permitted<sup class="footnote-ref"><a href="#fn1" id="fnref1">[1]</a></sup> to use <code>&lt;div&gt;</code> elements to wrap pairs of <code>&lt;dt&gt;</code> and <code>&lt;dd&gt;</code> elements for layout purposes.</li>
-<li><strong><code>class=&quot;gel-sr&quot;</code> for <code>&lt;dt&gt;</code>:</strong> The definition titles (<code>&lt;dt&gt;</code>s) are only needed for non-visual clarification in screen reader output. They are hidden visually using the <code>gel-sr</code> class.</li>
-<li><strong>gel-icon:</strong> The SVG icon (if present) is hidden along with the display text. It takes <code>focusable=&quot;false&quot;</code> to remove it from focus order in some versions of IE and Edge<sup class="footnote-ref"><a href="#fn2" id="fnref2">[2]</a></sup></li>
-<li><strong><code>aria-hidden=&quot;true&quot;</code></strong> In some cases, the visually displayed text may not be sufficient for synthetic voice announcement. In these cases, the displayed text (and associated iconography) is hidden from assistive technologies with <code>aria-hidden=&quot;true&quot;</code><sup class="footnote-ref"><a href="#fn3" id="fnref3">[3]</a></sup> and an alternative wording is provided non-visually (using the <code>gel-sr</code> class to hide this text visually).</li>
+<li><strong><code>class=&quot;gel-sr&quot;</code> for <code>&lt;span&gt;</code>:</strong> These are only needed for non-visual clarification in screen reader output. They are hidden visually using the <code>gel-sr</code> class.</li>
+<li><strong>gel-icon:</strong> The SVG icon (if present) is hidden along with the display text. It takes <code>focusable=&quot;false&quot;</code> to remove it from focus order in some versions of IE and Edge<sup class="footnote-ref"><a href="#fn1" id="fnref1">[1]</a></sup></li>
+<li><strong><code>aria-hidden=&quot;true&quot;</code></strong> In some cases, the visually displayed text may not be sufficient for synthetic voice announcement. In these cases, the displayed text (and associated iconography) is hidden from assistive technologies with <code>aria-hidden=&quot;true&quot;</code><sup class="footnote-ref"><a href="#fn2" id="fnref2">[2]</a></sup> and an alternative wording is provided non-visually (using the <code>gel-sr</code> class to hide this text visually).</li>
 </ul>
 <h2 id="recommended-layout">Recommended layout</h2>
-<p>The <code>&lt;dl&gt;</code>, <code>&lt;dt&gt;</code>, and <code>&lt;dd&gt;</code> must have their user agent styles removed. The child <code>&lt;div&gt;</code>s are set to <code>inline-block</code>, with <code>white-space: nowrap</code>.</p>
-<pre><code class="prettyprint syntax-css">.gel-metadata-strip &gt; div {
+<p>The <code>&lt;ul&gt;</code> must have its user agent styles removed. The child <code>&lt;li&gt;</code>s are set to <code>inline-block</code>, with <code>white-space: nowrap</code>.</p>
+<pre><code class="prettyprint syntax-css">.gel-metadata-strip &gt; li {
   display: inline-block;
   white-space: nowrap;
 }
 </code></pre>
-<p>The purpose of <code>nowrap</code> is to ensure pairs of definition titles and their definitions wrap together and are never split across lines. This aids scanning and comprehension.</p>
-<p>A border separator is included between—and only between—definition <code>&lt;div&gt;</code>s using pseudo-content:</p>
-<pre><code class="prettyprint syntax-css">.gel-metadata-strip &gt; div + div::before {
+<p>The purpose of <code>nowrap</code> is to ensure pairs of titles and descriptions wrap together and are never split across lines. This aids scanning and comprehension.</p>
+<p>A border separator is included between—and only between—definition <code>&lt;li&gt;</code>s using pseudo-content:</p>
+<pre><code class="prettyprint syntax-css">.gel-metadata-strip &gt; li + li::before {
   content: '';
   border-left: 1px solid;
   margin: 0 0.25rem;
@@ -157,7 +156,7 @@
 </code></pre>
 <p>This is preferable to using a character such as a pip (&quot;|&quot;) which will be announced unhelpfully in some screen readers.</p>
 <h3 id="links">Links</h3>
-<p>Some metadata values may be linked, such as the 'From' value in the <a href="#expected-markup"><strong>Expected markup</strong></a> example. It is important these links are not differentiated by colour alone<sup class="footnote-ref"><a href="#fn4" id="fnref4">[4]</a></sup>. People who are colour-blind or who use non-colour displays cannot perceive colour differences and will not be able to distinguish the link.</p>
+<p>Some metadata values may be linked, such as the 'From' value in the <a href="#expected-markup"><strong>Expected markup</strong></a> example. It is important these links are not differentiated by colour alone<sup class="footnote-ref"><a href="#fn3" id="fnref3">[3]</a></sup>. People who are colour-blind or who use non-colour displays cannot perceive colour differences and will not be able to distinguish the link.</p>
 <p>Accompany any colour differentiation with <code>text-decoration: underline</code>, if this style is not already being inherited.</p>
 <pre><code class="prettyprint syntax-css">.gel-metadata-strip a {
   text-decoration: underline;
@@ -208,13 +207,11 @@ title: Metadata Strips
 <hr class="footnotes-sep">
 <section class="footnotes">
 <ol class="footnotes-list">
-<li id="fn1" class="footnote-item"><p>&quot;Allow &lt;div&gt; around each &lt;dt&gt;&lt;dd&gt; group in &lt;dl&gt;&quot; (WHATWG merged pull request), <a href="https://github.com/whatwg/html/pull/1945">https://github.com/whatwg/html/pull/1945</a> <a href="#fnref1" class="footnote-backref">↩︎</a></p>
+<li id="fn1" class="footnote-item"><p>Don't make every <code>&lt;svg&gt;</code> focusable by default (issue) — Microsoft, <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8090208/">https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8090208/</a> <a href="#fnref1" class="footnote-backref">↩︎</a></p>
 </li>
-<li id="fn2" class="footnote-item"><p>Don't make every <code>&lt;svg&gt;</code> focusable by default (issue) — Microsoft, <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8090208/">https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8090208/</a> <a href="#fnref2" class="footnote-backref">↩︎</a></p>
+<li id="fn2" class="footnote-item"><p>&quot;Accessibility chops: <code>hidden</code> and <code>aria-hidden</code>&quot; — The Paciello Group, <a href="https://developer.paciellogroup.com/blog/2012/05/html5-accessibility-chops-hidden-and-aria-hidden/">https://developer.paciellogroup.com/blog/2012/05/html5-accessibility-chops-hidden-and-aria-hidden/</a> <a href="#fnref2" class="footnote-backref">↩︎</a></p>
 </li>
-<li id="fn3" class="footnote-item"><p>&quot;Accessibility chops: <code>hidden</code> and <code>aria-hidden</code>&quot; — The Paciello Group, <a href="https://developer.paciellogroup.com/blog/2012/05/html5-accessibility-chops-hidden-and-aria-hidden/">https://developer.paciellogroup.com/blog/2012/05/html5-accessibility-chops-hidden-and-aria-hidden/</a> <a href="#fnref3" class="footnote-backref">↩︎</a></p>
-</li>
-<li id="fn4" class="footnote-item"><p>Use Of Color: Understanding WCAG 1.4.1, <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html">https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html</a> <a href="#fnref4" class="footnote-backref">↩︎</a></p>
+<li id="fn3" class="footnote-item"><p>Use Of Color: Understanding WCAG 1.4.1, <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html">https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html</a> <a href="#fnref3" class="footnote-backref">↩︎</a></p>
 </li>
 </ol>
 </section>

--- a/docs/components/metadata-strips/index.html
+++ b/docs/components/metadata-strips/index.html
@@ -89,7 +89,7 @@
                 <dl class="geltags-standout-box">
                     
                     <dt>Version:</dt>
-                    <dd>0.1.0</dd>
+                    <dd>1.0.0</dd>
                     
                     <dt>Status:</dt>
                     <dd>Published</dd>


### PR DESCRIPTION
Ticket: https://jira.dev.bbc.co.uk/browse/DPTOPICS-1184
Slack thread (for more context): [#help-webcore-ux](https://bbc-dpg.slack.com/archives/CSGJQ1QFQ/p1651597827698769)

Following the changes made to to support Metadata Snippets without a title ([web PR](https://github.com/bbc/web/pull/8173)), this PR updates the associated GEL documentation with said component and respective changes.

These doc changes would eventually be visible at https://bbc.github.io/gel/components/metadata-strips/