### PR TITLE
Updates guidance on more drawer closing behaviour

### DIFF
--- a/_content/components/global-navigation.md
+++ b/_content/components/global-navigation.md
@@ -119,7 +119,7 @@ Services that appear within the priority links subcomponent do not appear within
 
 The more menu control is a link with an accessible name of “More Menu”.
 
-The more menu drawer should immediately follows the more menu control in the source order, it may be present later in the source order but this is not ideal. The more menu drawer must be contained within an element with an implicit or explicit role of `navigation` and an accessible name of “More Menu”:
+The more menu drawer should immediately follow the more menu control in the source order, it may be present later in the source order but this is not ideal. The more menu drawer must be contained within an element with an implicit or explicit role of `navigation` and an accessible name of “More Menu”:
 
 ```html
 <a href="#gel-masthead__more">More menu</a>
@@ -167,7 +167,7 @@ When the more menu drawer is opened and closed using a keyboard, animation shoul
 
 When the more menu drawer is opened by activating the more menu control with a keyboard `ENTER` or `SPACE` keypress, focus should be set to the first link within the more menu drawer. When the more menu drawer is opened by activating the more menu control with a click or an interaction that simulates a click event, focus should be set to the more menu drawer container.
 
-The more menu drawer can be closed by either activating the more menu control while the more menu is open, pressing the `ESC` key when focus is within the more menu drawer, or by moving focus away from the more menu drawer container. In all cases, focus should be set to the more menu control when the drawer is closed.
+The more menu drawer can be closed by either activating the more menu control while the more menu is open, pressing the `ESC` key when focus is within the more menu drawer, or activating the close button within the drawer. The more menu drawer should remain open even when tabbing moves focus off the drawer. When the more drawer is closed by user action, focus should be returned to the more menu control.
 
 ### Search module
 


### PR DESCRIPTION
The guidance regarding how the more menu drawer should close has changed. The more drawer should now close based on user interaction specifically closing the drawer rather than closing as a consequence of the user tabbing away from the drawer. Loss of focus within the drawer should not result in its closure. 

This PR updates the guidance to reflect these changes.